### PR TITLE
Multithreading and Request Pools

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,33 +1,28 @@
 from concurrent.futures import ThreadPoolExecutor
-from abc import ABC, abstractmethod
-from functools import partial
-from threading import Thread
-
-import requests as rq
 from datetime import datetime as dt
-import httpx as hx
-import itertools
-import json
+import requests as rq
+
 import time
-import os
 
-data = [('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ]
+data = ['lists', 'cards', 'checklists']
+params = {'key': '637c56e248984ec499c0361ccb63f695',
+'token': '44162f9fa00913303974d79d1151c3414ee0d9978f2e6720ebff65adf5afe3bf'}
 
-def fn(name, age):
-    # name = tup[0]
-    # age = tup[1]
-    print(name, age, dt.now().time())
-    time.sleep(1)
+def fn(arg):
+    return rq.request('GET', f'https://api.trello.com/1/boards/62221524f3b7441300da7a88/{arg}', params=params)
+
+def multi(arg):
+    with ThreadPoolExecutor(100) as executor:
+        res = executor.submit(fn, arg)
+    return res.result()
 
 start = time.perf_counter()
-with ThreadPoolExecutor(100) as executor:
-    for args in data:
-        new_fn = partial(fn, args[0])
-        executor.map(new_fn, (args[1],))
+res = []
+for arg in data:
+    res.append(multi(arg))
 
-# fn(*data[0])
-# fn(*data[1])
-# fn(*data[2])
+for r in res:
+    print(r)
 
 end = time.perf_counter()
 print(end-start)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,33 @@
+from concurrent.futures import ThreadPoolExecutor
+from abc import ABC, abstractmethod
+from functools import partial
+from threading import Thread
+
+import requests as rq
+from datetime import datetime as dt
+import httpx as hx
+import itertools
+import json
+import time
+import os
+
+data = [('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ('Paulo', 33), ('Stela', 27), ('Laura', 27), ]
+
+def fn(name, age):
+    # name = tup[0]
+    # age = tup[1]
+    print(name, age, dt.now().time())
+    time.sleep(1)
+
+start = time.perf_counter()
+with ThreadPoolExecutor(100) as executor:
+    for args in data:
+        new_fn = partial(fn, args[0])
+        executor.map(new_fn, (args[1],))
+
+# fn(*data[0])
+# fn(*data[1])
+# fn(*data[2])
+
+end = time.perf_counter()
+print(end-start)

--- a/trello.py
+++ b/trello.py
@@ -350,18 +350,18 @@ class BaseObject(ABC):
         for obj in js:
             print(json.dumps(obj, indent=4, sort_keys=False))
 
-    # SCRIPT METHODS ####################################################### 
+    # SCRIPT METHODS #######################################################
     def set_children(self):
         """Fully setup all objects belonging to the layer hierarchically below this object.
         Example: when called from a Board object, this method will setup all lists belonging to
         that board."""
 
-        fn_sw = {'boards': self.get_lists, 
+        fnc_sw = {'boards': self.get_lists, 
                   'lists':  self.get_cards, 
                   'cards': self.get_checklists}
         
         self.app.queue(self.get_self)
-        self.app.queue(fn_sw[self.__prefix])
+        self.app.queue(fnc_sw[self.__prefix])
         self.app.execute()
 
         obj_sw = {'boards': self.lists, 
@@ -457,25 +457,3 @@ class Checklist(BaseObject):
     @property
     def checkitems(self):
         return self.__checkitems
-
-key = '637c56e248984ec499c0361ccb63f695'
-token = '44162f9fa00913303974d79d1151c3414ee0d9978f2e6720ebff65adf5afe3bf'
-brd_id = '62221524f3b7441300da7a88'
-
-start = time.perf_counter()
-
-
-app = App(key, token)
-brd = Board(app, brd_id)
-
-# brd.set_children()
-for i in range(30):
-    app.queue(brd.get_self)
-app.execute()
-
-brd.dump()
-# brd.dump([lst.json for lst in brd.lists])
-
-
-end = time.perf_counter()
-print(f'{end-start:.4f} seconds')

--- a/trello.py
+++ b/trello.py
@@ -349,4 +349,3 @@ class Checklist(TrelloBaseObject):
     @property
     def checkitems(self):
         return self.__checkitems
-


### PR DESCRIPTION
Added a queue() and execute() layer to handle request multithreading. Whenever a request is queued, it is sent to a list of pools, each containing up to 10 requests (default). When execute() is called with no arguments, all requests are executed concurrently and returned in queueing order.

Other small changes and fixes were made.